### PR TITLE
Update protocol.ksy

### DIFF
--- a/reference/protocol.ksy
+++ b/reference/protocol.ksy
@@ -36,7 +36,7 @@ instances:
 enums:
   # The protocol version covered by this specification
   protocol_version:
-    17: value
+    18: value
   enum_blocktype:
     0x00: invalid
     0x01: not_a_block


### PR DESCRIPTION
I'm using the protocol spec to get `nanocap` going with TCP support, etc, and noticed the version hasn't been bumped.